### PR TITLE
Moved static variables to private members in Triangle2D

### DIFF
--- a/Rasterizer/Geometry2D.h
+++ b/Rasterizer/Geometry2D.h
@@ -85,6 +85,9 @@ public:
 * @brief A 2D triangle
 */
 class Triangle2D {
+	Vector2D prevVectors[3];
+	bool initialCalculation = false;
+
 	Vector2D vectors[3];
 
 	void CalculateVectors();

--- a/Rasterizer/geometry2D.cpp
+++ b/Rasterizer/geometry2D.cpp
@@ -69,9 +69,6 @@ bool Vector2D::operator==(Vector2D other) {
 }
 
 void Triangle2D::CalculateVectors() {
-	static Vector2D prevVectors[3];
-	static bool initialCalculation = false;
-	
 	if (   
 		initialCalculation &&
 		prevVectors[0] == vectors[0] &&


### PR DESCRIPTION
Removed static variables in `CalculateVectors()` member function of Triangle2D, moves them to private members of the Triangle2D class.

Closes #2